### PR TITLE
Add Snakefile for this step

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,34 @@
 A repository to develop a workflow linking Matlab and R to generate and analyse a large number of simulations.
 
 
+## Steps to run the workflow
+
+### Install iBridges
+
+```shell
+pip install ibridges
+```
+
+### Setup and check iBridges installation
+
+```shell
+ibridges init
+```
+
+### Install SnakeMake iRODS/iBridges plugin
+
+The ibridges/snakemake plugin needs to installed from a branch in a fork:
+
+```shell
+pip install git+https://github.com/qubixes/snakemake-storage-plugin-irods.git@switch-to-ibridges
+```
+
+## Run the workflow
+
+```shell
+snakemake --cores all
+```
+
 ## Authors
 
 Scientific contents:

--- a/Snakefile
+++ b/Snakefile
@@ -1,0 +1,20 @@
+
+def aggregate_output(wildcards):
+    return storage(expand("irods://nluu12p/home/research-test-christine/triangle/{param_file}.mat",
+                          param_file=glob_wildcards("data/sea-level_curves/{param_file}.txt").param_file))
+
+
+rule all:
+    input:
+        aggregate_output
+
+
+rule matlab:
+    input:
+        "data/sea-level_curves/{param_file}.txt"
+    output:
+        storage("irods://nluu12p/home/research-test-christine/triangle/{param_file}.mat")
+    shell:
+        "cd src/CarboCATLite;"
+        "echo \"CarboCAT_cli('params/DbPlatform/paramsInputValues.txt', 'params/DbPlatform/paramsProcesses.txt', '{wildcards.param_file}', '../../{input}', false); exit\" | matlab -nodesktop -nosplash;"
+        "mv {wildcards.param_file}.mat ../../{output}"


### PR DESCRIPTION
This adds basic automation to the Carbolite workflow. It locally creates the .mat file and uploads it to YoDa (currently the wrong collection, but I do not have access to the correct one). It is probably Linux/MacOS only because of the piping to circumvent the SyntaxError. 

Fixes #2 