### PR TITLE
Switch the snakefile to julia

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,37 +1,38 @@
 from snakemake.io import glob_wildcards
 
-def aggregate_output(wildcards):
-    return storage(expand("irods://nluu11p/home/research-mindthegap/triangle/{param_file}.mat",
-                  param_file=glob_wildcards("data/sea-level_curves/{param_file}.txt").param_file))
+BASE_COLLECTION="irods://nluu11p/home/research-mindthegap/triangle"
 
-def strat_output(wildcards):
-    return storage(expand("irods://nluu11p/home/research-mindthegap/triangle/strat-col/{param_file}_sc.mat",
-                  param_file=glob_wildcards("data/sea-level_curves/{param_file}.txt").param_file))
+def aggregate_output(wildcards):
+    param_file = glob_wildcards(storage(BASE_COLLECTION + "/sea-level_curves/{param_file}.txt")).param_file
+    return storage(expand(BASE_COLLECTION + "/output/{param_file}.h5",
+                  param_file=param_file))
+
+# def strat_output(wildcards):
+#     return storage(expand("irods://nluu11p/home/research-mindthegap/triangle/strat-col/{param_file}_sc.mat",
+#                   param_file=glob_wildcards("data/sea-level_curves/{param_file}.txt").param_file))
 
 rule all:
     input:
-        strat_output
+        aggregate_output
 
 
 
 rule matlab:
-   input:
-       "data/sea-level_curves/{param_file}.txt"
-   output:
-       storage("irods://nluu11p/home/research-mindthegap/triangle/{param_file}.mat")
-   shell:
-       "cd src/CarboCATLite;"
-       "echo \"CarboCAT_cli('params/DbPlatform/paramsInputValues.txt', 'params/DbPlatform/paramsProcesses.txt', '{wildcards.param_file}', '../../{input}', false); exit\" | matlab -nodesktop -nosplash;"
-       "mv {wildcards.param_file}.mat ../../{output};"
-
-
-rule extract_data:
     input:
-        storage("irods://nluu11p/home/research-mindthegap/triangle/{param_file}.mat")
+        storage("irods://nluu11p/home/research-mindthegap/triangle/sea-level_curves/{param_file}.txt")
     output:
-        storage("irods://nluu11p/home/research-mindthegap/triangle/strat-col/{param_file}_sc.mat")
-
+        storage("irods://nluu11p/home/research-mindthegap/triangle/output/{param_file}.h5")
     shell:
-        "cd src/CarboCAT_utils;"
-        "echo \"get_strat_columns([20, 50, 80, 120], [2, 2, 2, 2, 5, 5, 5, 5, 7, 7, 7, 7], '../../{input}','{wildcards.param_file}_sc'); exit\" | matlab -nodesktop -nosplash;"
-        "mv {wildcards.param_file}_sc.mat ../../{output};"
+        "julia src/Julia/external_SL.jl {input} {output}"
+
+
+# rule extract_data:
+#     input:
+#         storage("irods://nluu11p/home/research-mindthegap/triangle/{param_file}.mat")
+#     output:
+#         storage("irods://nluu11p/home/research-mindthegap/triangle/strat-col/{param_file}_sc.mat")
+
+#     shell:
+#         "cd src/CarboCAT_utils;"
+#         "echo \"get_strat_columns([20, 50, 80, 120], [2, 2, 2, 2, 5, 5, 5, 5, 7, 7, 7, 7], '../../{input}','{wildcards.param_file}_sc'); exit\" | matlab -nodesktop -nosplash;"
+#         "mv {wildcards.param_file}_sc.mat ../../{output};"


### PR DESCRIPTION
I have switched the SnakeMake workflow to use the new CarboKitten package. There was a bug in the snakemake storage plugin, so you'll have to update to the latest version for that. I have set it up so that the input data are also read from YoDa, so you can add more files there to test how it behaves with many parallel jobs.
